### PR TITLE
J Shaw30 add support for the Eufy t9120

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a library for parsing data from Eufy smart scales that use the EufyLife 
 
 | Model | Name               |
 | ----- | ------------------ |
+| T9120 | Smart Scale A1     |
 | T9140 | Smart Scale        |
 | T9146 | Smart Scale C1     |
 | T9147 | Smart Scale P1     |
@@ -17,3 +18,13 @@ This is a library for parsing data from Eufy smart scales that use the EufyLife 
 Install this via pip:
 
 `pip install eufylife-ble-client`
+
+## Dependencies
+
+Install this via pip
+
+`pip install bleak`
+
+`pip install bleak-retry-connector`
+
+`pip install cryptography`


### PR DESCRIPTION
Add support for the Eufy t9120

Used BLE Scanner and ESPHome to confirm BLE Characteristics and the bytes for weight.
weight_kg = ((data[4] << 8) | data[3]) / 100 
This is correct for the t9120.