### PR TITLE
Add support for heart rate and impedance to T9130 (C20)

### DIFF
--- a/eufylife_ble_client/models.py
+++ b/eufylife_ble_client/models.py
@@ -19,4 +19,5 @@ class EufyLifeBLEState:
     weight_kg: float = None
     final_weight_kg: float = None
     heart_rate: float = None
+    impedance: float = None
     max_weight_exceeded: bool = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eufylife-ble-client"
-version = "0.1.10"
+version = "0.1.11"
 description = "A library to communicate with EufyLife Bluetooth devices."
 authors = ["Brandon Rothweiler <brandonrothweiler@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
I've had a look at the data coming from my C20 smart scale, and I think I figured out how heart rate and impedance is encoded:

data[10] seems to be a bitfield, indicating what is included in the advertisment.
0x01: weight
0x04: final weight
0x40: impedance
0x80: heart rate

data[12:13] is the weight (either real-time or final, depending on 0x04 bit in data[10])
It's encoded as a little endian 16-bit unsigned integer with a resolution of 10g per LSB.

data[15] is the heart rate in bpm, encoded as an 8 bit unsigned integer.

data[17:18] is the impedance, encoded as a little endian 16-bit unsigned integer with a resolution of 100mOhm per LSB.

I tested it together with an extended version of the eufylife_ble custom integration based on the one you shared here:
https://github.com/bdr99/eufylife-ble-client/issues/5#issuecomment-2705294925

Here's my extended version of the eufylife_ble custom integration that supports heart rate and impedance for the C20 smart scale:
[eufylife_ble_experimental_c20_impedance_heart_rate_support.zip](https://github.com/user-attachments/files/24553347/eufylife_ble_experimental_c20_impedance_heart_rate_support.zip)

I see a plausible value for impedance and the same heart rate value as is shown on the scale itself:
<img width="661" height="179" alt="grafik" src="https://github.com/user-attachments/assets/0c407b66-e3ac-486c-a1cc-81fa1d34d124" />

When I connect the weight and impedance sensors to  [bodymiscale](https://github.com/dckiller51/bodymiscale),  I see the same body fat etc. values, as shown on the smart scale.

<img width="665" height="723" alt="grafik" src="https://github.com/user-attachments/assets/8a64c170-ce53-4df2-b717-618364c857cb" />

